### PR TITLE
Add missing semicolon to content type header

### DIFF
--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -58,7 +58,7 @@ func CSPMiddleware(next http.Handler) http.Handler {
 
 func TextHTMLMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html charset=utf-8")
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
This prevented safari from rendering the page, as reported in issue #12 