### PR TITLE
Change relative paths to root relative paths in stylesheet and script links

### DIFF
--- a/internal/templates/layout.templ
+++ b/internal/templates/layout.templ
@@ -13,9 +13,9 @@ templ header(title string) {
 		<script src="/static/script/response-targets.js" nonce={ middleware.GetResponseTargetsNonce(ctx) }></script>
 		<link rel="stylesheet" href="/static/css/style.min.css" nonce={ middleware.GetTwNonce(ctx) }/>
 		// if os.Getenv("env") == "production" {
-		// 	<link rel="stylesheet" href="static/css/style.min.css" nonce={ middleware.GetTwNonce(ctx) }/>
+		// 	<link rel="stylesheet" href="/static/css/style.min.css" nonce={ middleware.GetTwNonce(ctx) }/>
 		// } else {
-		// 	<link rel="stylesheet" href="static/css/style.css" nonce={ middleware.GetTwNonce(ctx) }/>
+		// 	<link rel="stylesheet" href="/static/css/style.css" nonce={ middleware.GetTwNonce(ctx) }/>
 		// }
 	</head>
 }

--- a/internal/templates/layout.templ
+++ b/internal/templates/layout.templ
@@ -9,9 +9,9 @@ templ header(title string) {
 		<title>{ title }</title>
 		<meta charset="UTF-8"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-		<script src="static/script/htmx.min.js" nonce={ middleware.GetHtmxNonce(ctx) }></script>
-		<script src="static/script/response-targets.js" nonce={ middleware.GetResponseTargetsNonce(ctx) }></script>
-		<link rel="stylesheet" href="static/css/style.min.css" nonce={ middleware.GetTwNonce(ctx) }/>
+		<script src="/static/script/htmx.min.js" nonce={ middleware.GetHtmxNonce(ctx) }></script>
+		<script src="/static/script/response-targets.js" nonce={ middleware.GetResponseTargetsNonce(ctx) }></script>
+		<link rel="stylesheet" href="/static/css/style.min.css" nonce={ middleware.GetTwNonce(ctx) }/>
 		// if os.Getenv("env") == "production" {
 		// 	<link rel="stylesheet" href="static/css/style.min.css" nonce={ middleware.GetTwNonce(ctx) }/>
 		// } else {


### PR DESCRIPTION
Hey! 

I've enjoyed the GoTHH stack so far! However, there might be a problem for people who want to expand the template app further in their own projects.

**Problem:** Relative paths in the stylesheet and script links cause the app to load CSS and JS files from incorrect paths when fetching resources in routes of 2 segments or more (so /a/b/). This leads to CSS and JavaScript not working on those pages. Illustration below (file fetched from /activities and not /).

<img width="500" alt="Screenshot 2025-01-23 at 18 36 06" src="https://github.com/user-attachments/assets/929ab592-d9d3-45e4-8f4f-8766482693eb" />

**Suggested fix:** Easy fix would be to change the paths from relative to **root relative paths**. This fixes the problem.

Example:
```html
Change this
<link href="static/css/style.css" rel="stylesheet" type="text/css">
To this
<link href="/static/css/style.css" rel="stylesheet" type="text/css">
```

<img width="500" alt="Screenshot 2025-01-23 at 18 36 27" src="https://github.com/user-attachments/assets/a93e212c-ca9f-4e0a-928c-1b78ac5326cf" />